### PR TITLE
fix: add missing functions

### DIFF
--- a/internal/functions/accel_noasm.go
+++ b/internal/functions/accel_noasm.go
@@ -550,3 +550,12 @@ func ToInt32_AVX2_F32(x []int32, y []float32) {
 func ToInt64_AVX2_F32(x []int64, y []float32) {
 	panic("not implemented")
 }
+
+// extras
+func Pow_AVX2_F32(x, y []float32) {
+	panic("not implemented")
+}
+
+func Pow_AVX2_F64(x, y []float64) {
+	panic("not implemented")
+}


### PR DESCRIPTION
this results in build error on unsupported architectures and appears to be an oversight.

confirmed working on my M1 Mac. 